### PR TITLE
log more information about s3 and client state when getting a mismatc…

### DIFF
--- a/datastore.go
+++ b/datastore.go
@@ -2,6 +2,8 @@ package tusd
 
 import (
 	"io"
+	"strconv"
+	"time"
 )
 
 type MetaData map[string]string
@@ -25,6 +27,45 @@ type FileInfo struct {
 	// ordered slice containing the ids of the uploads of which the final upload
 	// will consist after concatenation.
 	PartialUploads []string
+	//Added for diagnosing annoying mismatch offsets for wistia uploads
+	Parts []Part
+}
+
+type Part struct {
+
+	// Entity tag returned when the part was uploaded.
+	ETag *string `type:"string"`
+
+	// Date and time at which the part was uploaded.
+	LastModified *time.Time `type:"timestamp"`
+
+	// Part number identifying the part. This is a positive integer between 1 and
+	// 10,000.
+	PartNumber *int64 `type:"integer"`
+
+	// Size in bytes of the uploaded part data.
+	Size *int64 `type:"integer"`
+	// contains filtered or unexported fields
+}
+
+func (p Part) String() string {
+	etag := ""
+	lastModified := ""
+	partNumber := ""
+	size := ""
+	if p.ETag != nil {
+		etag = *p.ETag
+	}
+	if p.LastModified != nil {
+		lastModified = p.LastModified.String()
+	}
+	if p.PartNumber != nil {
+		partNumber = strconv.FormatInt(*p.PartNumber, 10)
+	}
+	if p.Size != nil {
+		size = strconv.FormatInt(*p.Size, 10)
+	}
+	return "etag: " + etag + ",lastModified: " + lastModified + ",partNumber: " + partNumber + ",size: " + size
 }
 
 type DataStore interface {

--- a/s3store/s3store.go
+++ b/s3store/s3store.go
@@ -415,6 +415,8 @@ func (store S3Store) GetInfo(id string) (info tusd.FileInfo, err error) {
 		offset += *part.Size
 	}
 
+	info.Parts = convertParts(parts)
+
 	incompletePartObject, err := store.getIncompletePartForUpload(uploadId)
 	if err != nil {
 		return info, err
@@ -615,6 +617,20 @@ func (store S3Store) DeclareLength(id string, length int64) error {
 	info.SizeIsDeferred = false
 
 	return store.writeInfo(uploadId, info)
+}
+
+func convertParts(parts []*s3.Part) []tusd.Part {
+	var convertedParts []tusd.Part
+	for _, part := range parts {
+		convertedPart := tusd.Part {
+			ETag: part.ETag,
+			LastModified: part.LastModified,
+			PartNumber: part.PartNumber,
+			Size: part.Size,
+		}
+		convertedParts = append(convertedParts, convertedPart)
+	}
+	return convertedParts
 }
 
 func (store S3Store) listAllParts(id string) (parts []*s3.Part, err error) {

--- a/unrouted_handler.go
+++ b/unrouted_handler.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"io"
 	"log"
 	"math"
@@ -455,6 +456,23 @@ func (handler *UnroutedHandler) PatchFile(w http.ResponseWriter, r *http.Request
 	}
 
 	if offset != info.Offset {
+		parts := info.Parts
+		loggableParts := ""
+		for _, part := range parts {
+			loggableParts += part.String() + ":"
+		}
+		handler.log("ErrMismatchOffset",
+			"id", id,
+			"size", strconv.FormatInt(info.Size, 10),
+			"size is deferred?", strconv.FormatBool(info.SizeIsDeferred),
+			"header offset", strconv.FormatInt(offset, 10),
+			"s3 offset", strconv.FormatInt(info.Offset, 10),
+			"metadata", fmt.Sprintf("%v", info.MetaData),
+			"is partial?", strconv.FormatBool(info.IsPartial),
+			"is final?", strconv.FormatBool(info.IsFinal),
+			"partial uploads", strings.Join(info.PartialUploads[:], ","),
+			"upload parts", loggableParts)
+
 		handler.sendError(w, r, ErrMismatchOffset)
 		return
 	}


### PR DESCRIPTION
…hed offset error

Add a local Part type to datastore.go so that s3store.go can write s3 response information into that so that we can log that information when we receive a mismatched offset error.

Related granary PR to use this branch:
https://github.com/wistia/granary/pull/246